### PR TITLE
fix: make sure tasks are processed deterministically

### DIFF
--- a/packages/background-task-connector-entity-storage/src/entityStorageBackgroundTaskConnector.ts
+++ b/packages/background-task-connector-entity-storage/src/entityStorageBackgroundTaskConnector.ts
@@ -685,7 +685,7 @@ export class EntityStorageBackgroundTaskConnector implements IBackgroundTaskConn
 								nextTask.dateModified = new Date(Date.now()).toISOString();
 								await this._backgroundTaskEntityStorageConnector.set(nextTask);
 
-								setTimeout(async () => this.runTask(nextTask));
+								await this.runTask(nextTask);
 							} else {
 								this._logging?.log({
 									level: "error",

--- a/packages/background-task-connector-entity-storage/tests/entityStorageBackgroundTaskConnector.spec.ts
+++ b/packages/background-task-connector-entity-storage/tests/entityStorageBackgroundTaskConnector.spec.ts
@@ -107,17 +107,7 @@ describe("EntityStorageBackgroundTaskConnector", () => {
 		await backgroundTaskConnector.create("my-type", { counter: 0 });
 
 		const store = backgroundTaskEntityStorageConnector.getStore();
-		expect(store).toMatchObject([
-			{
-				id: "00000000000000000000000000000000",
-				payload: {
-					counter: 0
-				},
-				retainFor: 0,
-				status: "processing",
-				type: "my-type"
-			}
-		]);
+		expect(store).toMatchObject([]);
 	});
 
 	test("can create a task with handler and retainment", async () => {

--- a/scripts/validate-branch-name.mjs
+++ b/scripts/validate-branch-name.mjs
@@ -7,7 +7,9 @@ const pattern = /^(feature|bugfix|hotfix|release|chore)\/[\da-z-]+?$/;
 
 if (!pattern.test(branchName) && branchName !== 'next') {
 	process.stderr.write(`ERROR: Branch name '${branchName}' doesn't match the required pattern.\n`);
-	process.stderr.write('Branch names should start: feature/, bugfix/, hotfix/, release/ or chore/\n');
+	process.stderr.write(
+		'Branch names should start: feature/, bugfix/, hotfix/, release/ or chore/\n'
+	);
 	process.stderr.write('and the name should consist of lowercase letters, numbers and hyphens.\n');
 	// eslint-disable-next-line unicorn/no-process-exit
 	process.exit(1);


### PR DESCRIPTION
When running background tasks from tests the use of a setTimeout causes unexpected timing issues, there is no need to use a setTimeout at this point as the task itself is properly threaded at a later stage