### PR TITLE
fix(schema): change `retainUntil` column to BIGINT

### DIFF
--- a/packages/background-task-connector-entity-storage/src/entities/backgroundTask.ts
+++ b/packages/background-task-connector-entity-storage/src/entities/backgroundTask.ts
@@ -77,7 +77,7 @@ export class BackgroundTask {
 	/**
 	 * The timestamp of when to retain the task until.
 	 */
-	@property({ type: "number", optional: true })
+	@property({ type: "integer", optional: true, format: "uint64" })
 	public retainUntil?: number;
 
 	/**


### PR DESCRIPTION
Fix float precision loss when storing timestamps in the database. i.e `1750327060777` becomes `1750330000000.0` when stored as a float because the float representation cannot accurately represent the large integer value.

